### PR TITLE
Sparql protocol conform

### DIFF
--- a/Main/ghttp.cpp
+++ b/Main/ghttp.cpp
@@ -83,6 +83,8 @@ bool export_handler(const HttpServer& server, const shared_ptr<HttpServer::Respo
 
 bool query_handler0(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType);
 
+bool query_handler0_sparql_conform(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType);
+
 bool query_handler1(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType);
 
 bool monitor_handler(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType);
@@ -1110,6 +1112,10 @@ int initialize(int argc, char* argv[])
   server.resource["^/\\?operation=query&db_name=(.*)&format=(.*)&sparql=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		query_handler0(server, response, request, "GET");
   };
+
+    server.resource["^/\\?db_name=(.*)&query=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+        query_handler0_sparql_conform(server, response, request, "GET");
+    };
 
   //POST-example for the path /query0, responds with the matched string in path
   server.resource["/query0"]["POST"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
@@ -2721,6 +2727,8 @@ void query_thread(bool update_flag, string db_name, string format, string db_que
       PrettyWriter<StringBuffer> resWriter(resBuffer);
       resDoc.Accept(resWriter);
       success = resBuffer.GetString();
+    } else if (format == "sparql-results+json") {
+      success = rs.to_JSON(); // convert the result to json
     } else {
       //	cout << "query success, transfer to str." << endl;
       success = rs.to_str();
@@ -2728,6 +2736,8 @@ void query_thread(bool update_flag, string db_name, string format, string db_que
     if (format == "html") {
       localname = localname + ".txt";
       filename = filename + ".txt";
+    } else if (format == "sparql-results+json") {
+      // file is not stored locally
     } else {
       localname = localname + "." + format;
       filename = filename + "." + format;
@@ -2774,6 +2784,18 @@ void query_thread(bool update_flag, string db_name, string format, string db_que
       //*response  << "\r\n\r\n" << "0+" << query_time_s<< '+' << rs.ansNum << '+' << filename << '+' << success;
       pthread_rwlock_unlock(&(it_already_build->second->db_lock));
       //return true;
+      return;
+    } else if (format == "sparql-results+json") {
+      // write the result to the response
+      // headers taken from html-format, modified Content-Type
+      *response << "HTTP/1.1 200 OK\r\nContent-Type: application/sparql-results+json\r\nContent-Length: " << success.length();
+      *response << "\r\nCache-Control: no-cache"
+                << "\r\nPragma: no-cache"
+                << "\r\nExpires: 0";
+      *response << "\r\n\r\n" << success; // success contains the json-encoded result
+
+      pthread_rwlock_unlock(&(it_already_build->second->db_lock));
+
       return;
     } else {
       string filename = "";
@@ -2852,6 +2874,38 @@ bool query_handler0(const HttpServer& server, const shared_ptr<HttpServer::Respo
   Task* task = new Task(0, db_name, format, db_query, response, request);
   pool.AddTask(task);
   return true;
+}
+
+bool query_handler0_sparql_conform(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType)
+{
+    string thread_id = Util::getThreadID();
+    string log_prefix = "thread " + thread_id + " -- ";
+    cout << log_prefix << "HTTP: this is query_handler0_sparql_conform" << endl;
+    cout << "request->path: " << request->path << endl;
+
+    if (RequestType != "GET") {
+        cout << log_prefix << "Implementation is currently limited to requests sent via GET." << endl;
+        return false;
+    }
+
+    string db_name = request->path_match[1];
+    db_name = UrlDecode(db_name);
+    string db_query = request->path_match[2];
+    db_query = UrlDecode(db_query);
+    string format = "sparql-results+json";
+
+    //check if the db_name is system
+    if (db_name == "system") {
+        string error = "no query privilege, operation failed.";
+        string resJson = CreateJson(404, error, 0);
+        *response << "HTTP/1.1 200 OK\r\nContent-Type: application/sparql-results+json\r\nContent-Length: " << resJson.length() << "\r\n\r\n" << resJson;
+        return false;
+    }
+
+    query_num++;
+    Task* task = new Task(0, db_name, format, db_query, response, request);
+    pool.AddTask(task);
+    return true;
 }
 
 bool query_handler1(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType)

--- a/Main/ghttp.cpp
+++ b/Main/ghttp.cpp
@@ -930,7 +930,7 @@ int initialize(int argc, char* argv[])
 		build_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=build&db_name=(.*)&ds_path=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=build&db_name=(.*)&ds_path=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		build_handler(server, response, request, "GET");
@@ -950,7 +950,7 @@ int initialize(int argc, char* argv[])
 		load_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=load&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=load&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		load_handler(server, response, request, "GET");
@@ -970,7 +970,7 @@ int initialize(int argc, char* argv[])
 		unload_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=unload&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=unload&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		unload_handler(server, response, request, "GET");
@@ -990,7 +990,7 @@ int initialize(int argc, char* argv[])
 		login_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=login&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=login&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		login_handler(server, response, request, "GET");
@@ -1008,7 +1008,7 @@ int initialize(int argc, char* argv[])
 		user_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=user&type=(.*)&username1=(.*)&password1=(.*)&username2=(.*)&addition=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=user&type=(.*)&username1=(.*)&password1=(.*)&username2=(.*)&addition=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		user_handler(server, response, request, "GET");
   };
 
@@ -1022,7 +1022,7 @@ int initialize(int argc, char* argv[])
 		showUser_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=showUser&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=showUser&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		showUser_handler(server, response, request, "GET");
   };
 
@@ -1036,7 +1036,7 @@ int initialize(int argc, char* argv[])
 		query_handler1(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=query&username=(.*)&password=(.*)&db_name=(.*)&format=(.*)&sparql=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=query&username=(.*)&password=(.*)&db_name=(.*)&format=(.*)&sparql=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		query_handler1(server, response, request, "GET");
   };
 
@@ -1050,7 +1050,7 @@ int initialize(int argc, char* argv[])
 		export_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=export&db_name=(.*)&ds_path=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=export&db_name=(.*)&ds_path=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		export_handler(server, response, request, "GET");
   };
 
@@ -1064,7 +1064,7 @@ int initialize(int argc, char* argv[])
 		check_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=check&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=check&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		check_handler(server, response, request, "GET");
   };
 
@@ -1078,7 +1078,7 @@ int initialize(int argc, char* argv[])
 		drop_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=drop&db_name=(.*)&username=(.*)&password=(.*)&is_backup=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=drop&db_name=(.*)&username=(.*)&password=(.*)&is_backup=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		drop_handler(server, response, request, "GET");
   };
 
@@ -1091,7 +1091,7 @@ int initialize(int argc, char* argv[])
 		refresh_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=refresh&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=refresh&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		refresh_handler(server, response, request, "GET");
   };
 
@@ -1107,7 +1107,7 @@ int initialize(int argc, char* argv[])
 		query_handler0(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=query&db_name=(.*)&format=(.*)&sparql=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=query&db_name=(.*)&format=(.*)&sparql=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		query_handler0(server, response, request, "GET");
   };
 
@@ -1121,7 +1121,7 @@ int initialize(int argc, char* argv[])
 		monitor_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=monitor&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=monitor&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		monitor_handler(server, response, request, "GET");
   };
 
@@ -1135,7 +1135,7 @@ int initialize(int argc, char* argv[])
 		if (flag)
 			exit(0);
   };
-  server.resource["^/?operation=stop&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=stop&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		bool flag = stop_handler(server, response, request);
 		if(flag)
 			exit(0);
@@ -1146,7 +1146,7 @@ int initialize(int argc, char* argv[])
 		checkpoint_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=checkpoint&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=checkpoint&db_name=(.*)&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		checkpoint_handler(server, response, request, "GET");
   };
 
@@ -1160,7 +1160,7 @@ int initialize(int argc, char* argv[])
 		show_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=show&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=show&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		show_handler(server, response, request, "GET");
   };
 
@@ -1173,7 +1173,7 @@ int initialize(int argc, char* argv[])
 		getCoreVersion_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=getCoreVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=getCoreVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		getCoreVersion_handler(server, response, request, "GET");
   };
 
@@ -1187,7 +1187,7 @@ int initialize(int argc, char* argv[])
 		setCoreVersion_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=setCoreVersion&username=(.*)&password=(.*)&version=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=setCoreVersion&username=(.*)&password=(.*)&version=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		setCoreVersion_handler(server, response, request, "GET");
   };
 
@@ -1203,7 +1203,7 @@ int initialize(int argc, char* argv[])
 		initVersion_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=initVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=initVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		initVersion_handler(server, response, request, "GET");
@@ -1223,7 +1223,7 @@ int initialize(int argc, char* argv[])
 		getAPIVersion_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=getAPIVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=getAPIVersion&username=(.*)&password=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		string req_url = request->path;
 		cout << "request url: " << req_url << endl;
 		getAPIVersion_handler(server, response, request, "GET");
@@ -1241,7 +1241,7 @@ int initialize(int argc, char* argv[])
 		setAPIVersion_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=setAPIVersion&username=(.*)&password=(.*)&version=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=setAPIVersion&username=(.*)&password=(.*)&version=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		setAPIVersion_handler(server, response, request, "GET");
   };
 
@@ -1266,7 +1266,7 @@ int initialize(int argc, char* argv[])
 		delete_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=delete&filepath=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=delete&filepath=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		delete_handler(server, response, request, "GET");
   };
 
@@ -1280,7 +1280,7 @@ int initialize(int argc, char* argv[])
 		download_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=download&filepath=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=download&filepath=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		download_handler(server, response, request, "GET");
   };
 
@@ -1305,7 +1305,7 @@ int initialize(int argc, char* argv[])
 		backup_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=backup&db_name=(.*)&username=(.*)&password=(.*)&path=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=backup&db_name=(.*)&username=(.*)&password=(.*)&path=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		backup_handler(server, response, request, "GET");
   };
 
@@ -1318,7 +1318,7 @@ int initialize(int argc, char* argv[])
 		restore_handler(server, response, request, "GET");
   };
 
-  server.resource["^/?operation=restore&db_name=(.*)&username=(.*)&password=(.*)&path=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
+  server.resource["^/\\?operation=restore&db_name=(.*)&username=(.*)&password=(.*)&path=(.*)$"]["GET"] = [&server](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
 		restore_handler(server, response, request, "GET");
   };
 
@@ -2851,6 +2851,7 @@ bool query_handler0(const HttpServer& server, const shared_ptr<HttpServer::Respo
   query_num++;
   Task* task = new Task(0, db_name, format, db_query, response, request);
   pool.AddTask(task);
+  return true;
 }
 
 bool query_handler1(const HttpServer& server, const shared_ptr<HttpServer::Response>& response, const shared_ptr<HttpServer::Request>& request, string RequestType)


### PR DESCRIPTION
We include gStore in a paper on triple stores. For benchmarking we had to adopt a few changes, to provide a SPARQL protocol (**not to be mixed up with SPARQL Query Language**) conform endpoint, i.e. HTTP GET with query parameters. We tried to keep code changes to an absolute minimum and did not break any interfaces. 

The changes include: 
* fixing all RegExes for parsing query parameters with a `?`. The RegExes used a bare `?` which is a reserved character in the [Perl Regular Expressions used here through boost](https://www.boost.org/doc/libs/1_73_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html) here. It is now escaped. 
* added a query handler `query_handler0_sparql_conform` that handles queries like: http://localhost:9000/?db_name=swdf&query=select%20distinct%20%3Fx%20where%20%0A{%20%0A%09%3Fx%20%20%20%20%3Fy%20%3Fz.%20%0A}%20%0A
  * query is accepted by `query` parameter instead of `sparql` as required by [SPARQL protocol](https://www.w3.org/TR/2008/REC-rdf-sparql-protocol-20080115/#query-bindings-http).
  * response result type is set to the correct result type for [Query Results JSON Format](https://www.w3.org/TR/sparql11-results-json/), i.e. `application/sparql-results+json`.
  * JSON is returned unformatted, as this is not required for non-human consumers
  * result is not serialized to disc. 

We introduced the SPARQL protocol conform endpoint only for an unprivileged request. But it should be easy for you to adopt also the other mapped request forms as you like. 

If you have any questions about the suggested changes, I will be glad to help.